### PR TITLE
Make findBlock async, return original block from BlockConverter by default

### DIFF
--- a/scripts/BlockConverter.ts
+++ b/scripts/BlockConverter.ts
@@ -118,6 +118,9 @@ export class BlockConverter {
           break;
       }
     }
+    if(baseType === "") {
+      baseType = type;
+    }
     return new CodexBlockType(blockConverter, baseType);
   }
 }

--- a/scripts/CodexBot.ts
+++ b/scripts/CodexBot.ts
@@ -33,7 +33,7 @@ export interface Bot extends SimulatedPlayer {
   navigateLocation: (worldLocation: Location | Block[], speed?: number) => Promise<void>;
   followEntity: (player: Entity, speed?: number) => Promise<void>;
 
-  findBlock: (type: string, maxRadius: number) => Block[];
+  findBlock: (type: string, maxRadius: number, numFind: number) => Promise<Block[]>;
   mineBlock: (block: Block[]) => Promise<boolean>;
   interactBlock: (block: Block[]) => boolean;
   sortClosestBlock: (blocks: Block[]) => Block[];
@@ -166,7 +166,7 @@ export class CodexBot {
   }
 
   // adapted from https://stackoverflow.com/questions/37214057/3d-array-traversal-originating-from-center
-  findBlock(type: string, maxRadius: number = 16, numFind: number = 1): Block[] {
+  async findBlock(type: string, maxRadius: number = 16, numFind: number = 1): Promise<Block[]> {
     let diameter = maxRadius * 2;
     const start = new BlockLocation(this.simBot.location.x, this.simBot.location.y, this.simBot.location.z);
     let blocks: Block[] = [];
@@ -177,6 +177,8 @@ export class CodexBot {
 
     let codexBlockType = BlockConverter.ConvertBlockType(type);
     let coreBlockType = "minecraft:" + codexBlockType.name;
+    this.chat("Finding " + numFind + " " + type + " blocks");
+    this.chat("Converted " + type + " to " + coreBlockType);
 
     var half = Math.ceil(diameter / 2) - 1;
     for (var d = 0; d <= 3 * half; d++) {
@@ -220,7 +222,7 @@ export class CodexBot {
   }
   checkBlock(x: number, y: number, z: number, start: BlockLocation, blocks: Block[], coreBlockType: string) {
     const loc = new BlockLocation(start.x + x, start.y + y, start.z + z);
-    const block = game!.overWorld.getBlock(loc);
+    const block = this.simBot.dimension.getBlock(loc);
 
     // adding this check sped up the search by factor of 10
     if (block.isEmpty) return;

--- a/scripts/prompts/combinedPrompt.ts
+++ b/scripts/prompts/combinedPrompt.ts
@@ -12,7 +12,7 @@ export let context: Context = {
 // listInventory(object: Block | SimulatedPlayer | Player): InventoryComponentContainer - returns a container enumerating all the items a player or treasure chest has
 // getLocation() : BlockLocation - returns the location from the simulated player
 // navigateLocation(worldLocation: Location : Block, speed?: number) : Promise<NavigationResult> - path find through the world to a location
-// findBlock(type: string, maxRadius: number, numFind : number = 1): Block [] - Returns the an arry of blocks closest to the simulated player of the type given within the radius.
+// findBlock(type: string, maxRadius: number, numFind : number = 1): Promise<Block []> - Returns the an arry of blocks closest to the simulated player of the type given within the radius.
 // folllowEntity(entity: Entity, speed? : number): Promise<void> - Orders the simulated player to move to the given entity.
 // mineBlock(blockArr : Block []) : boolean - simulated player mines a block and places it in their inventory
 // collectNearbyItems() : number - Collects nearby items that may be on the ground - for example, mined ore
@@ -169,7 +169,7 @@ bot.craftItem("stick");
 bot.craftItem("wooden_sword");
 
 //find and open a chest
-state.chest = bot.findBlock("chest", 16, 1);
+state.chest = await bot.findBlock("chest", 16, 1);
 await bot.navigateLocation(state.chest);
 if(bot.interactBlock(state.chest)) bot.chat("I have opened the chest")
 


### PR DESCRIPTION
Making FindBlock Async prevents blocking the main thread during searches, which prevents world modification events from being registered until the search succeeds.
We also need to return the original block from BlockConverter if its not modified, for items without modifications to pass through the converter and to findBlock